### PR TITLE
Fix css warnings

### DIFF
--- a/app/assets/stylesheets/bootstrap_builder/bootstrap.css
+++ b/app/assets/stylesheets/bootstrap_builder/bootstrap.css
@@ -2593,7 +2593,7 @@ button.close {
   background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#ffffff), to(#e6e6e6));
   background-image: -webkit-linear-gradient(top, #ffffff, #e6e6e6);
   background-image: -o-linear-gradient(top, #ffffff, #e6e6e6);
-  background-image: linear-gradient(top, #ffffff, #e6e6e6);
+  background-image: linear-gradient(to bottom, #ffffff, #e6e6e6);
   background-image: -moz-linear-gradient(top, #ffffff, #e6e6e6);
   background-repeat: repeat-x;
   border: 1px solid #cccccc;
@@ -2741,7 +2741,7 @@ button.close {
   background-image: -webkit-linear-gradient(top, #0088cc, #0055cc);
   background-image: -o-linear-gradient(top, #0088cc, #0055cc);
   background-image: -moz-linear-gradient(top, #0088cc, #0055cc);
-  background-image: linear-gradient(top, #0088cc, #0055cc);
+  background-image: linear-gradient(to bottom, #0088cc, #0055cc);
   background-repeat: repeat-x;
   border-color: #0055cc #0055cc #003580;
   border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
@@ -2771,7 +2771,7 @@ button.close {
   background-image: -webkit-linear-gradient(top, #fbb450, #f89406);
   background-image: -o-linear-gradient(top, #fbb450, #f89406);
   background-image: -moz-linear-gradient(top, #fbb450, #f89406);
-  background-image: linear-gradient(top, #fbb450, #f89406);
+  background-image: linear-gradient(to bottom, #fbb450, #f89406);
   background-repeat: repeat-x;
   border-color: #f89406 #f89406 #ad6704;
   border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
@@ -2801,7 +2801,7 @@ button.close {
   background-image: -webkit-linear-gradient(top, #ee5f5b, #bd362f);
   background-image: -o-linear-gradient(top, #ee5f5b, #bd362f);
   background-image: -moz-linear-gradient(top, #ee5f5b, #bd362f);
-  background-image: linear-gradient(top, #ee5f5b, #bd362f);
+  background-image: linear-gradient(to bottom, #ee5f5b, #bd362f);
   background-repeat: repeat-x;
   border-color: #bd362f #bd362f #802420;
   border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
@@ -2831,7 +2831,7 @@ button.close {
   background-image: -webkit-linear-gradient(top, #62c462, #51a351);
   background-image: -o-linear-gradient(top, #62c462, #51a351);
   background-image: -moz-linear-gradient(top, #62c462, #51a351);
-  background-image: linear-gradient(top, #62c462, #51a351);
+  background-image: linear-gradient(to bottom, #62c462, #51a351);
   background-repeat: repeat-x;
   border-color: #51a351 #51a351 #387038;
   border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
@@ -2861,7 +2861,7 @@ button.close {
   background-image: -webkit-linear-gradient(top, #5bc0de, #2f96b4);
   background-image: -o-linear-gradient(top, #5bc0de, #2f96b4);
   background-image: -moz-linear-gradient(top, #5bc0de, #2f96b4);
-  background-image: linear-gradient(top, #5bc0de, #2f96b4);
+  background-image: linear-gradient(to bottom, #5bc0de, #2f96b4);
   background-repeat: repeat-x;
   border-color: #2f96b4 #2f96b4 #1f6377;
   border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
@@ -2891,7 +2891,7 @@ button.close {
   background-image: -webkit-linear-gradient(top, #555555, #222222);
   background-image: -o-linear-gradient(top, #555555, #222222);
   background-image: -moz-linear-gradient(top, #555555, #222222);
-  background-image: linear-gradient(top, #555555, #222222);
+  background-image: linear-gradient(to bottom, #555555, #222222);
   background-repeat: repeat-x;
   border-color: #222222 #222222 #000000;
   border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
@@ -3585,7 +3585,7 @@ input[type="submit"].btn.btn-mini {
   background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#333333), to(#222222));
   background-image: -webkit-linear-gradient(top, #333333, #222222);
   background-image: -o-linear-gradient(top, #333333, #222222);
-  background-image: linear-gradient(top, #333333, #222222);
+  background-image: linear-gradient(to bottom, #333333, #222222);
   background-repeat: repeat-x;
   -webkit-border-radius: 4px;
      -moz-border-radius: 4px;
@@ -3849,7 +3849,7 @@ input[type="submit"].btn.btn-mini {
   background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#333333), to(#222222));
   background-image: -webkit-linear-gradient(top, #333333, #222222);
   background-image: -o-linear-gradient(top, #333333, #222222);
-  background-image: linear-gradient(top, #333333, #222222);
+  background-image: linear-gradient(to bottom, #333333, #222222);
   background-image: -moz-linear-gradient(top, #333333, #222222);
   background-repeat: repeat-x;
   border-color: #222222 #222222 #000000;
@@ -3979,7 +3979,7 @@ input[type="submit"].btn.btn-mini {
   background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#ffffff), to(#f5f5f5));
   background-image: -webkit-linear-gradient(top, #ffffff, #f5f5f5);
   background-image: -o-linear-gradient(top, #ffffff, #f5f5f5);
-  background-image: linear-gradient(top, #ffffff, #f5f5f5);
+  background-image: linear-gradient(to bottom, #ffffff, #f5f5f5);
   background-repeat: repeat-x;
   border: 1px solid #ddd;
   -webkit-border-radius: 3px;
@@ -4644,7 +4644,7 @@ a.badge:hover {
   background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#f5f5f5), to(#f9f9f9));
   background-image: -webkit-linear-gradient(top, #f5f5f5, #f9f9f9);
   background-image: -o-linear-gradient(top, #f5f5f5, #f9f9f9);
-  background-image: linear-gradient(top, #f5f5f5, #f9f9f9);
+  background-image: linear-gradient(to bottom, #f5f5f5, #f9f9f9);
   background-repeat: repeat-x;
   -webkit-border-radius: 4px;
      -moz-border-radius: 4px;
@@ -4667,7 +4667,7 @@ a.badge:hover {
   background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#149bdf), to(#0480be));
   background-image: -webkit-linear-gradient(top, #149bdf, #0480be);
   background-image: -o-linear-gradient(top, #149bdf, #0480be);
-  background-image: linear-gradient(top, #149bdf, #0480be);
+  background-image: linear-gradient(to bottom, #149bdf, #0480be);
   background-image: -ms-linear-gradient(top, #149bdf, #0480be);
   background-repeat: repeat-x;
   filter: progid:dximagetransform.microsoft.gradient(startColorstr='#149bdf', endColorstr='#0480be', GradientType=0);
@@ -4714,7 +4714,7 @@ a.badge:hover {
   background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#ee5f5b), to(#c43c35));
   background-image: -webkit-linear-gradient(top, #ee5f5b, #c43c35);
   background-image: -o-linear-gradient(top, #ee5f5b, #c43c35);
-  background-image: linear-gradient(top, #ee5f5b, #c43c35);
+  background-image: linear-gradient(to bottom, #ee5f5b, #c43c35);
   background-repeat: repeat-x;
   filter: progid:dximagetransform.microsoft.gradient(startColorstr='#ee5f5b', endColorstr='#c43c35', GradientType=0);
 }
@@ -4736,7 +4736,7 @@ a.badge:hover {
   background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#62c462), to(#57a957));
   background-image: -webkit-linear-gradient(top, #62c462, #57a957);
   background-image: -o-linear-gradient(top, #62c462, #57a957);
-  background-image: linear-gradient(top, #62c462, #57a957);
+  background-image: linear-gradient(to bottom, #62c462, #57a957);
   background-repeat: repeat-x;
   filter: progid:dximagetransform.microsoft.gradient(startColorstr='#62c462', endColorstr='#57a957', GradientType=0);
 }
@@ -4758,7 +4758,7 @@ a.badge:hover {
   background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#5bc0de), to(#339bb9));
   background-image: -webkit-linear-gradient(top, #5bc0de, #339bb9);
   background-image: -o-linear-gradient(top, #5bc0de, #339bb9);
-  background-image: linear-gradient(top, #5bc0de, #339bb9);
+  background-image: linear-gradient(to bottom, #5bc0de, #339bb9);
   background-repeat: repeat-x;
   filter: progid:dximagetransform.microsoft.gradient(startColorstr='#5bc0de', endColorstr='#339bb9', GradientType=0);
 }
@@ -4780,7 +4780,7 @@ a.badge:hover {
   background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#fbb450), to(#f89406));
   background-image: -webkit-linear-gradient(top, #fbb450, #f89406);
   background-image: -o-linear-gradient(top, #fbb450, #f89406);
-  background-image: linear-gradient(top, #fbb450, #f89406);
+  background-image: linear-gradient(to bottom, #fbb450, #f89406);
   background-repeat: repeat-x;
   filter: progid:dximagetransform.microsoft.gradient(startColorstr='#fbb450', endColorstr='#f89406', GradientType=0);
 }


### PR DESCRIPTION
This PR should fix this:

```
autoprefixer: /home/travis/build/greengage-mobile/green_gauge_rails/vendor/bundle/ruby/2.3.0/gems/bootstrap_builder-0.4.0/app/assets/stylesheets/bootstrap_builder/bootstrap.css:2597:3: Gradient has outdated direction syntax. New syntax is like `to left` instead of `right`.
autoprefixer: /home/travis/build/greengage-mobile/green_gauge_rails/vendor/bundle/ruby/2.3.0/gems/bootstrap_builder-0.4.0/app/assets/stylesheets/bootstrap_builder/bootstrap.css:2745:3: Gradient has outdated direction syntax. New syntax is like `to left` instead of `right`.
autoprefixer: /home/travis/build/greengage-mobile/green_gauge_rails/vendor/bundle/ruby/2.3.0/gems/bootstrap_builder-0.4.0/app/assets/stylesheets/bootstrap_builder/bootstrap.css:2775:3: Gradient has outdated direction syntax. New syntax is like `to left` instead of `right`.
autoprefixer: /home/travis/build/greengage-mobile/green_gauge_rails/vendor/bundle/ruby/2.3.0/gems/bootstrap_builder-0.4.0/app/assets/stylesheets/bootstrap_builder/bootstrap.css:2805:3: Gradient has outdated direction syntax. New syntax is like `to left` instead of `right`.
autoprefixer: /home/travis/build/greengage-mobile/green_gauge_rails/vendor/bundle/ruby/2.3.0/gems/bootstrap_builder-0.4.0/app/assets/stylesheets/bootstrap_builder/bootstrap.css:2835:3: Gradient has outdated direction syntax. New syntax is like `to left` instead of `right`.
autoprefixer: /home/travis/build/greengage-mobile/green_gauge_rails/vendor/bundle/ruby/2.3.0/gems/bootstrap_builder-0.4.0/app/assets/stylesheets/bootstrap_builder/bootstrap.css:2865:3: Gradient has outdated direction syntax. New syntax is like `to left` instead of `right`.
autoprefixer: /home/travis/build/greengage-mobile/green_gauge_rails/vendor/bundle/ruby/2.3.0/gems/bootstrap_builder-0.4.0/app/assets/stylesheets/bootstrap_builder/bootstrap.css:2895:3: Gradient has outdated direction syntax. New syntax is like `to left` instead of `right`.
autoprefixer: /home/travis/build/greengage-mobile/green_gauge_rails/vendor/bundle/ruby/2.3.0/gems/bootstrap_builder-0.4.0/app/assets/stylesheets/bootstrap_builder/bootstrap.css:3589:3: Gradient has outdated direction syntax. New syntax is like `to left` instead of `right`.
autoprefixer: /home/travis/build/greengage-mobile/green_gauge_rails/vendor/bundle/ruby/2.3.0/gems/bootstrap_builder-0.4.0/app/assets/stylesheets/bootstrap_builder/bootstrap.css:3853:3: Gradient has outdated direction syntax. New syntax is like `to left` instead of `right`.
autoprefixer: /home/travis/build/greengage-mobile/green_gauge_rails/vendor/bundle/ruby/2.3.0/gems/bootstrap_builder-0.4.0/app/assets/stylesheets/bootstrap_builder/bootstrap.css:3983:3: Gradient has outdated direction syntax. New syntax is like `to left` instead of `right`.
autoprefixer: /home/travis/build/greengage-mobile/green_gauge_rails/vendor/bundle/ruby/2.3.0/gems/bootstrap_builder-0.4.0/app/assets/stylesheets/bootstrap_builder/bootstrap.css:4648:3: Gradient has outdated direction syntax. New syntax is like `to left` instead of `right`.
autoprefixer: /home/travis/build/greengage-mobile/green_gauge_rails/vendor/bundle/ruby/2.3.0/gems/bootstrap_builder-0.4.0/app/assets/stylesheets/bootstrap_builder/bootstrap.css:4671:3: Gradient has outdated direction syntax. New syntax is like `to left` instead of `right`.
autoprefixer: /home/travis/build/greengage-mobile/green_gauge_rails/vendor/bundle/ruby/2.3.0/gems/bootstrap_builder-0.4.0/app/assets/stylesheets/bootstrap_builder/bootstrap.css:4718:3: Gradient has outdated direction syntax. New syntax is like `to left` instead of `right`.
autoprefixer: /home/travis/build/greengage-mobile/green_gauge_rails/vendor/bundle/ruby/2.3.0/gems/bootstrap_builder-0.4.0/app/assets/stylesheets/bootstrap_builder/bootstrap.css:4740:3: Gradient has outdated direction syntax. New syntax is like `to left` instead of `right`.
autoprefixer: /home/travis/build/greengage-mobile/green_gauge_rails/vendor/bundle/ruby/2.3.0/gems/bootstrap_builder-0.4.0/app/assets/stylesheets/bootstrap_builder/bootstrap.css:4762:3: Gradient has outdated direction syntax. New syntax is like `to left` instead of `right`.
autoprefixer: /home/travis/build/greengage-mobile/green_gauge_rails/vendor/bundle/ruby/2.3.0/gems/bootstrap_builder-0.4.0/app/assets/stylesheets/bootstrap_builder/bootstrap.css:4784:3: Gradient has outdated direction syntax. New syntax is like `to left` instead of `right`.
```

Reference:  
- https://github.com/postcss/autoprefixer/issues/530
- https://github.com/skroutz/selectorablium/pull/12/files